### PR TITLE
Add support for metadata on server create

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ provider powered by [SmartDataCenter](http://www.joyent.com/products/smartdatace
     # Defaults to https://us-west-1.api.joyentcloud.com/
     knife[:joyent_api_url] = "https://us-sw-1.api.joyentcloud.com/"
 
+**joyent_metadata**
+
+Metadata to apply to each provisioned machine via the Metadata API. This should take
+the form of a hash with a single level of nesting. See the
+[Metadata API](http://wiki.joyent.com/wiki/display/sdc/Using+the+Metadata+API) for more info.
+
+    knife[:joyent_metadata] = {
+      "some_data" => "value"
+    }
+
 ## Contributors
 
  - [Sean Omera](https://github.com/someara) - Opscode


### PR DESCRIPTION
There are a few changes here, but the meat of it is to add support for machine metadata on server creation. This can be done in two ways. You can set the following in your knife.rb

``` ruby
knife[:joyent_metadata] = {
  "key" => "value"
}
```

or you can add the following to the `server create` command line

``` bash
--metadata '{"key":"value"}'
```

With the current implementation, only one level of key/value nesting is valid, ie value should be a string instead of another hash. Also, command line keys take precedence over the knife file.

Let me know what you think!
