### PR TITLE
Fix typo for --password long option

### DIFF
--- a/lib/chef/knife/joyent_base.rb
+++ b/lib/chef/knife/joyent_base.rb
@@ -21,7 +21,7 @@ class Chef
 
           option :joyent_password,
             :short => '-P PASSWORD',
-            :long => '--joyent-password PASSOWRD',
+            :long => '--joyent-password PASSWORD',
             :description => 'Your Joyent password',
             :proc => Proc.new {|key| Chef::Config[:knife][:joyent_password] = key }
 


### PR DESCRIPTION
Very minor typo fix.  The command usage was showing PASSWROD instead of PASSWORD.
