### PR TITLE
Space-delimit Machine IP's for display

### DIFF
--- a/lib/chef/knife/joyent_server_create.rb
+++ b/lib/chef/knife/joyent_server_create.rb
@@ -197,7 +197,7 @@ class Chef
         msg_pair("State", server.state)
         msg_pair("Type", server.type)
         msg_pair("Dataset", server.dataset)
-        msg_pair("IP's", server.ips)
+        msg_pair("IP's", server.ips.join(" "))
         msg_pair("JSON Attributes",config[:json_attributes]) unless config[:json_attributes].empty?
       end
 

--- a/lib/chef/knife/joyent_server_delete.rb
+++ b/lib/chef/knife/joyent_server_delete.rb
@@ -25,7 +25,7 @@ class Chef
         msg("State", server.state)
         msg("Type", server.type)
         msg("Dataset", server.dataset)
-        msg("IP's", server.ips)
+        msg("IP's", server.ips.join(" "))
        
         unless server
           puts ui.error("Unable to locate server: #{id}")


### PR DESCRIPTION
The IP's line for machines displayed in server create/delete puts no space between the public and private IP's.  This fix puts a space between them to improve readability.
