### PR TITLE
Explicitly pulling out the "provisioner" tag

### DIFF
--- a/lib/chef/knife/joyent_server_create.rb
+++ b/lib/chef/knife/joyent_server_create.rb
@@ -160,11 +160,10 @@ class Chef
             ui.color('Name', :bold),
             ui.color('Value', :bold),
           ]
-          server.add_tags({tagkey => tagvalue}).each do |k, v|
-            unless k == 'context'
-              tags << k
-              tags << v
-            end
+          response = server.add_tags({tagkey => tagvalue})
+          if response['provisioner']
+            tags << 'provisioner'
+            tags << response['provisioner']
           end
           puts ui.color("Updated tags for #{node_name}", :cyan)
           puts ui.list(tags, :uneven_columns_across, 2)


### PR DESCRIPTION
since ERB is not at all happy about trying to render the "context" tag value since it's a `Hash`, barfs on missing `#encoding` method.
