### PR TITLE
Fixing the formatting error I spoke of in the issue I opened  

### DIFF
--- a/lib/chef/knife/joyent_server_list.rb
+++ b/lib/chef/knife/joyent_server_list.rb
@@ -46,6 +46,8 @@ class Chef
 
           if (servers.tags rescue nil)
             servers << s.tags.map { |k, v| "#{k}:#{v}" }.join(' ')
+          else
+            servers << "No Tags"
           end
         end
 


### PR DESCRIPTION
Injecting a default string of "No Tags" to fill the column. Otherwise the next server in the list prints its first column in the prior row.
