### PR TITLE
snapshot list errors on nil state

### DIFF
--- a/lib/chef/knife/joyent_snapshot_list.rb
+++ b/lib/chef/knife/joyent_snapshot_list.rb
@@ -31,7 +31,7 @@ class Chef
           when "success" then
             ui.color(s.state, :green)
           else
-            ui.color(s.state, :red)
+            ui.color(s.state.to_s, :red)
           end
           snapshots << s.created.to_s
         end


### PR DESCRIPTION
Breaking changes to the SDC API remove state from snapshot lists in many cases. Knife-joyent expects state to be present, so when it is not there is an error:

ERROR: TypeError: no implicit conversion of nil into String
