### PR TITLE
Clarify usage for server create --name

### DIFF
--- a/lib/chef/knife/joyent_server_create.rb
+++ b/lib/chef/knife/joyent_server_create.rb
@@ -20,7 +20,7 @@ class Chef
       option :server_name,
         :short => "-S NAME",
         :long => "--server-name <name>",
-        :description => "The Joyent server name"
+        :description => "The Joyent server name (may contain letters, numbers, dashes, and periods)"
 
       option :chef_node_name,
         :short => "-N NAME",


### PR DESCRIPTION
Explain the allowed characters in machine names.
