### PR TITLE
Format RAM/disk numbers properly, and comma separate IPs

### DIFF
--- a/lib/chef/knife/joyent_server_list.rb
+++ b/lib/chef/knife/joyent_server_list.rb
@@ -41,19 +41,24 @@ class Chef
 
           servers << s.type
           servers << s.dataset
-          servers << s.attributes["package"] || 'Unknown'
+          servers << (s.respond_to?(:attributes) ? s.attributes["package"] : 'unknown')
           servers << s.ips.join(",")
-          servers << "#{sprintf "%6.2f", s.memory/1024.0} GB".to_s
-          servers << "#{sprintf "%5.0f",   s.disk/1024} GB".to_s
+          servers << "#{sprintf "%6.2f", s.memory/1024.0} GB"
+          servers << "#{sprintf "%5.0f", s.disk/1024} GB"
+
 
           if (s.tags rescue nil)
-            servers << s.tags.map { |k, v| "#{k}:#{v}" }.join(' ')
+            servers << (show_tags? ? s.tags.map { |k, v| "#{k}:#{v}" }.join(' ') : "")
           else
             servers << "No Tags"
           end
         end
 
         puts ui.list(servers, :uneven_columns_across, 10)
+      end
+
+      def show_tags?
+        !ENV['SHOW_TAGS'].nil?
       end
     end
   end


### PR DESCRIPTION
- space-separating IP addresses makes this very hard to parse, because it means each row has variable size number of columns (servers with 2 IPs have one extra column).  With comma-separated IPs this is a no-brainer to parse in awk or cut.
- numbers such as RAM and disk should be always right aligned for readability, and should support non-integer values for RAM, since the smallest instances offered by Joyent can have < 1GB RAM size.
