### PR TITLE
Update knife-joyent.gemspec

### DIFF
--- a/knife-joyent.gemspec
+++ b/knife-joyent.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.add_dependency "fog", "~> 1.15.0"
+  s.add_dependency "fog", ">= 1.15.0"
   s.add_dependency "multi_json", "~> 1.7"
   s.add_dependency "chef", ">= 0.10.10"
 


### PR DESCRIPTION
Proposing to allow later versions of fog gem so that this gem can coexist with other providers' gems.  

We have tested that server operations still work with fog-1.20.0 (create/delete/etc).  Is there any other reason to restrict it to 1.15.0 ?
