### PR TITLE
Adds support for --no-color option for pricing output

### DIFF
--- a/knife-joyent.gemspec
+++ b/knife-joyent.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "fog", "~> 1.21.0"
   s.add_dependency "multi_json", "~> 1.7"
   s.add_dependency "chef", "~> 11.6"
-  s.add_dependency "joyent-cloud-pricing", ">= 1.0.9"
+  s.add_dependency "joyent-cloud-pricing", ">= 1.0.10"
 
   s.add_development_dependency 'rspec'
 

--- a/lib/chef/knife/joyent_server_pricing.rb
+++ b/lib/chef/knife/joyent_server_pricing.rb
@@ -9,7 +9,7 @@ class Chef
       option :reserve_pricing,
              :short => '-r <file>',
              :long => '--reserve-pricing <file>',
-             :description => 'Apply reserve discounts from a YAML config (see joyent-cloud-pricing gem)',
+             :description => 'Apply custom pricing from a YAML file (see: joyent-cloud-pricing gem)',
              :proc => Proc.new { |key| Chef::Config[:knife][:reserve_pricing] = key }
 
       option :show_zones,
@@ -23,7 +23,7 @@ class Chef
              :description => 'Disable color when printing',
              :proc => Proc.new { |key| Chef::Config[:knife][:no_color] = true }
 
-      banner 'knife joyent server pricing [-r your-reserve-pricing.yml -z --no-color ...] '
+      banner 'knife joyent server pricing [-r <custom-pricing.yml>] [-z] [--no-color]'
 
       def run
         flavors = []


### PR DESCRIPTION
This is totally non-urgent, but I added support for `--no-color` option, which disables all colored output (which is great if you want to pipe the pricing report somewhere). Version 1.0.10 of joyent-cloud-pricing supports it, hence the dependency bump.
