### PR TITLE
upgrade the fog version to 1.23

### DIFF
--- a/knife-joyent.gemspec
+++ b/knife-joyent.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.add_dependency "fog", "~> 1.21.0"
+  s.add_dependency "fog", "~> 1.23.0"
   s.add_dependency "multi_json", "~> 1.7"
   s.add_dependency "chef", "~> 11.6"
   s.add_dependency "joyent-cloud-pricing", ">= 1.1.0"


### PR DESCRIPTION
if you are using newer version of chef and their knife plugins for aws or openstack the 1.21 for version is going to break your knife client. So I've upgrade this to 1.23 like knife-ec2 or knife-openstack.