### PR TITLE
Updated install instructions to match new ruby environment setup of Chef

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For more information on Joyent CloudAPI, see: [CloudAPI Documentation](https://a
 
 With chef already installed ``(> 0.10.0)``:
 
-    gem install knife-joyent
+    chef gem install knife-joyent
 
 ## Usage
 


### PR DESCRIPTION
Per the Chef Docs here: https://docs.chef.io/resource_gem_package.html

The chef_gem and gem_package resources are both used to install Ruby
gems. For any machine on which the chef-client is installed, there are
two instances of Ruby. One is the standard, system-wide instance of
Ruby and the other is a dedicated instance that is available only to
the chef-client. Use the chef_gem resource to install gems into the
instance of Ruby that is dedicated to the chef-client. Use the
gem_package resource to install all other gems (i.e. install gems
system-wide).

The gem needs to be installed in the proper ruby runtime environment.