### PR TITLE
We only want to call the response method when we know it will exist

### DIFF
--- a/lib/chef/knife/joyent_base.rb
+++ b/lib/chef/knife/joyent_base.rb
@@ -82,7 +82,7 @@ class Chef
         res = case e
         when Excon::Response
           e
-        when Excon::Errors::Error
+        when Excon::Errors::HTTPStatusError
           e.response
         else
           raise


### PR DESCRIPTION
Otherwise let it be handled higher up.  I blantantly pilfered this from
a fix to fog experiencing the same problem I was which was that it was
complaining that no response method existed
  - fog fix for similar error handling on excon https://github.com/fog/fog/pull/792/files

  - my stack trace
/opt/local/lib/ruby/gems/2.2.0/gems/knife-joyent-0.4.14/lib/chef/knife/joyent_base.rb:86:in `output_error': undefined method `response' for #<Excon::Errors::SocketError:0x00000003497480> (NoMethodError)
        from /opt/local/lib/ruby/gems/2.2.0/gems/knife-joyent-0.4.14/lib/chef/knife/joyent_image_list.rb:71:in `rescue in run'
        from /opt/local/lib/ruby/gems/2.2.0/gems/knife-joyent-0.4.14/lib/chef/knife/joyent_image_list.rb:30:in `run'
        from /opt/local/lib/ruby/gems/2.2.0/gems/chef-12.5.1/lib/chef/knife.rb:405:in `block in run_with_pretty_exceptions'
        from /opt/local/lib/ruby/gems/2.2.0/gems/chef-12.5.1/lib/chef/local_mode.rb:44:in `with_server_connectivity'
        from /opt/local/lib/ruby/gems/2.2.0/gems/chef-12.5.1/lib/chef/knife.rb:404:in `run_with_pretty_exceptions'
        from /opt/local/lib/ruby/gems/2.2.0/gems/chef-12.5.1/lib/chef/knife.rb:203:in `run'
        from /opt/local/lib/ruby/gems/2.2.0/gems/chef-12.5.1/lib/chef/application/knife.rb:142:in `run'
        from /opt/local/lib/ruby/gems/2.2.0/gems/chef-12.5.1/bin/knife:25:in `<top (required)>'
        from /opt/local/bin/knife:23:in `load'
        from /opt/local/bin/knife:23:in `<main>'